### PR TITLE
Switch jquery shim from $ to jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     ]
   },
   "browserify-shim": {
-    "jquery": "global:$"
+    "jquery": "global:jQuery"
   }
 }


### PR DESCRIPTION
jQuery noConflict seems to remove `$` from the global scope but not `jQuery`. This should fix it.