### PR TITLE
Fixed word wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "backbone-computedfields": "0.0.10",
     "backbone.marionette": "^2.4.1",
     "backbone.stickit": "^0.9.2",
+    "bootstrap": "^3.3.5",
     "cookie": "^0.1.2",
     "faye": "^1.1.1",
     "jquery": "~1.11.0",

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -1,3 +1,4 @@
+@import "../../node_modules/bootstrap/less/mixins.less";
 @import "mixins.less";
 @import "animations.less";
 

--- a/src/stylesheets/mixins.less
+++ b/src/stylesheets/mixins.less
@@ -1,13 +1,4 @@
 .word-break(){
-  -ms-word-break: break-all;
-
-     /* Be VERY careful with this, breaks normal words wh_erever */
-     word-break: break-all;
-
-     /* Non standard for webkit */
      word-break: break-word;
-
--webkit-hyphens: auto;
-   -moz-hyphens: auto;
-        hyphens: auto;
+    .hyphens();
 }


### PR DESCRIPTION
This fixes #49. It think `break-all` was the fix for long words. The current solution will break on word and hyphen long words.

The `.hyphens()` mixin is coming from Bootstrap and it takes care of proper vendor prefixes.

@juliangarritano @jpjoyal 