### PR TITLE
Support for gzip

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
             },
             dist: {
                 src: 'dist/supportkit.js',
-                dest: 'dist/supportkit.min.uncompressed.js'
+                dest: 'dist/supportkit.min.js'
             }
         },
 
@@ -145,8 +145,8 @@ module.exports = function(grunt) {
                 options: {
                     mode: 'gzip'
                 },
-                src: 'dist/supportkit.min.uncompressed.js',
-                dest: 'dist/supportkit.min.js'
+                src: 'dist/supportkit.min.js',
+                dest: 'dist/supportkit.min.compressed.js'
             }
         },
 
@@ -160,14 +160,14 @@ module.exports = function(grunt) {
             js: {
                 // Files to be uploaded.
                 upload: [{
-                    src: 'dist/supportkit.min.uncompressed.js',
-                    dest: 'supportkit.min.uncompressed.js'
-                }, {
-                    src: 'dist/supportkit.min.js',
-                    dest: 'supportkit.min.js',
+                    src: 'dist/supportkit.min.compressed.js',
+                    dest: 'supportkit.min.compressed.js',
                     options: {
                         gzip: true
                     }
+                }, {
+                    src: 'dist/supportkit.min.js',
+                    dest: 'supportkit.min.js'
                 }]
             },
             images: {
@@ -210,7 +210,7 @@ module.exports = function(grunt) {
                 CallerReference: Date.now().toString(),
                 Paths: {
                     Quantity: 1,
-                    Items: ['/supportkit.min.js', '/supportkit.min.uncompressed.js']
+                    Items: ['/supportkit.min.js', '/supportkit.min.compressed.js']
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
             },
             dist: {
                 src: 'dist/supportkit.js',
-                dest: 'dist/supportkit.min.js'
+                dest: 'dist/supportkit.min.uncompressed.js'
             }
         },
 
@@ -145,8 +145,8 @@ module.exports = function(grunt) {
                 options: {
                     mode: 'gzip'
                 },
-                src: 'dist/supportkit.min.js',
-                dest: 'dist/supportkit.min.js.gz'
+                src: 'dist/supportkit.min.uncompressed.js',
+                dest: 'dist/supportkit.min.js'
             }
         },
 
@@ -160,11 +160,11 @@ module.exports = function(grunt) {
             js: {
                 // Files to be uploaded.
                 upload: [{
-                    src: 'dist/supportkit.min.js',
-                    dest: 'supportkit.min.js'
+                    src: 'dist/supportkit.min.uncompressed.js',
+                    dest: 'supportkit.min.uncompressed.js'
                 }, {
-                    src: 'dist/supportkit.min.js.gz',
-                    dest: 'supportkit.min.js.gz',
+                    src: 'dist/supportkit.min.js',
+                    dest: 'supportkit.min.js',
                     options: {
                         gzip: true
                     }
@@ -210,7 +210,7 @@ module.exports = function(grunt) {
                 CallerReference: Date.now().toString(),
                 Paths: {
                     Quantity: 1,
-                    Items: ['/supportkit.min.js', '/supportkit.min.js.gz']
+                    Items: ['/supportkit.min.js', '/supportkit.min.uncompressed.js']
                 }
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,15 @@ module.exports = function(grunt) {
                 }
             }
         },
+        compress: {
+            main: {
+                options: {
+                    mode: 'gzip'
+                },
+                src: 'dist/supportkit.min.js',
+                dest: 'dist/supportkit.min.js.gz'
+            }
+        },
 
         s3: {
             options: {
@@ -152,7 +161,16 @@ module.exports = function(grunt) {
                 // Files to be uploaded.
                 upload: [{
                     src: 'dist/supportkit.min.js',
-                    dest: 'supportkit.min.js'
+                    dest: 'supportkit.min.js',
+                    options: {
+                        gzip: true
+                    }
+                }, {
+                    src: 'dist/supportkit.min.js.gz',
+                    dest: 'supportkit.min.js.gz',
+                    options: {
+                        gzip: true
+                    }
                 }]
             },
             images: {
@@ -195,7 +213,7 @@ module.exports = function(grunt) {
                 CallerReference: Date.now().toString(),
                 Paths: {
                     Quantity: 1,
-                    Items: ['/supportkit.min.js']
+                    Items: ['/supportkit.min.js', '/supportkit.min.js.gz']
                 }
             }
         },
@@ -348,7 +366,7 @@ module.exports = function(grunt) {
         grunt.config.set('config.WIDGET_CODE', 'supportkit.min.js');
     });
 
-    grunt.registerTask('build', ['clean', 'browserify', 'uglify']);
+    grunt.registerTask('build', ['clean', 'browserify', 'uglify', 'compress']);
     grunt.registerTask('devbuild', ['clean', 'browserify', 'loadConfig', 'replace']);
     grunt.registerTask('devbuild:min', ['clean', 'browserify', 'loadConfig', 'setMinMode', 'replace', 'uglify']);
     grunt.registerTask('deploy', ['build', 'awsconfig', 's3:js', 'cloudfront:prod']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -161,10 +161,7 @@ module.exports = function(grunt) {
                 // Files to be uploaded.
                 upload: [{
                     src: 'dist/supportkit.min.js',
-                    dest: 'supportkit.min.js',
-                    options: {
-                        gzip: true
-                    }
+                    dest: 'supportkit.min.js'
                 }, {
                     src: 'dist/supportkit.min.js.gz',
                     dest: 'supportkit.min.js.gz',

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "grunt-cloudfront": "^0.2.1",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-cssmin": "^0.11.0",
     "grunt-contrib-less": "^1.0.0",

--- a/release_notes/v0.2.19.md
+++ b/release_notes/v0.2.19.md
@@ -1,0 +1,5 @@
+# Features
+- Support for gzip
+
+This release is mostly a test run to see if it doesn't break stuff in prod.
+


### PR DESCRIPTION
As per AWS documentation, we need to create a second compressed file and upload it to S3 with gzip encoding. 

This would partly fix #58. I think we still need some server-side/CDN config to serve the right file.

@jpjoyal  @alavers @juliangarritano 