### PR TITLE
Close the settings view on save

### DIFF
--- a/src/js/controllers/chatController.js
+++ b/src/js/controllers/chatController.js
@@ -284,6 +284,9 @@ module.exports = ViewController.extend({
             }
         });
 
+
+        this.listenToOnce(settingsController, 'settings:close', this._hideSettings);
+
         this.listenToOnce(settingsController, 'destroy', function() {
             this.stopListening(settingsController);
         });

--- a/src/js/controllers/settingsController.js
+++ b/src/js/controllers/settingsController.js
@@ -29,11 +29,11 @@ module.exports = ViewController.extend({
     },
 
     onSettingsSave: function() {
-        this.listenToOnce(this.model, 'sync', function() {
-            this.trigger('settings:close');
-        });
-
         if (this.isDirty) {
+            this.listenToOnce(this.model, 'sync', function() {
+                this.trigger('settings:close');
+            });
+
             // bypass throttling
             this.model._save({}, {
                 wait: true

--- a/src/js/controllers/settingsController.js
+++ b/src/js/controllers/settingsController.js
@@ -30,13 +30,17 @@ module.exports = ViewController.extend({
 
     onSettingsSave: function() {
         this.listenToOnce(this.model, 'sync', function() {
-            this.view.showSavedMessage();
+            this.trigger('settings:close');
         });
 
-        // bypass throttling
-        this.model._save({}, {
-            wait: true
-        });
+        if (this.isDirty) {
+            // bypass throttling
+            this.model._save({}, {
+                wait: true
+            });
+        } else {
+            this.trigger('settings:close');
+        }
     },
 
     onEmailChange: function() {


### PR DESCRIPTION
This behavior was asked by a couple of users and even by us during review. This streamlines the email capture experience for the end user and get them back to the conversation as fast as possible.
