### PR TITLE
Fix for the version in CDN banner and removed compression

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -367,8 +367,4 @@ module.exports = function(grunt) {
     grunt.registerTask('branchCheck', 'Checks that you are publishing from Master branch with no working changes', ['gitinfo', 'checkBranchStatus']);
 
     grunt.registerTask('cdnify', ['awsconfig', 's3:images']);
-
-    grunt.registerTask('bannerPkg', function(){
-        grunt.log.warn(grunt.config.get('globalVersion'))
-    })
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function(grunt) {
         // Metadata
         pkg: grunt.file.readJSON('package.json'),
         license: grunt.file.read('LICENSE'),
+        globalVersion: '<%= pkg.version %>',
         banner: '/*! \n\t<%= pkg.name %> <%= globalVersion %> \n\t<%= license %> \n*/\n',
         // Task configuration
         clean: ['dist/*'],
@@ -140,16 +141,6 @@ module.exports = function(grunt) {
                 }
             }
         },
-        compress: {
-            main: {
-                options: {
-                    mode: 'gzip',
-                    level: 5
-                },
-                src: 'dist/supportkit.min.js',
-                dest: 'dist/supportkit.min.js.gz'
-            }
-        },
 
         s3: {
             options: {
@@ -163,15 +154,6 @@ module.exports = function(grunt) {
                 upload: [{
                     src: 'dist/supportkit.min.js',
                     dest: 'supportkit.min.js'
-                }, {
-                    src: 'dist/supportkit.min.js.gz',
-                    dest: 'supportkit.min.js.gz',
-                    options: {
-                        gzip: true,
-                        headers: {
-                            'Content-Type': 'text/javascript'
-                        }
-                    }
                 }]
             },
             images: {
@@ -213,8 +195,8 @@ module.exports = function(grunt) {
                 },
                 CallerReference: Date.now().toString(),
                 Paths: {
-                    Quantity: 2,
-                    Items: ['/supportkit.min.js', '/supportkit.min.js.gz']
+                    Quantity: 1,
+                    Items: ['/supportkit.min.js']
                 }
             }
         },
@@ -368,7 +350,7 @@ module.exports = function(grunt) {
         grunt.config.set('config.WIDGET_CODE', 'supportkit.min.js');
     });
 
-    grunt.registerTask('build', ['clean', 'browserify', 'uglify', 'compress']);
+    grunt.registerTask('build', ['clean', 'browserify', 'uglify']);
     grunt.registerTask('devbuild', ['clean', 'browserify', 'loadConfig', 'replace']);
     grunt.registerTask('devbuild:min', ['clean', 'browserify', 'loadConfig', 'setMinMode', 'replace', 'uglify']);
     grunt.registerTask('deploy', ['build', 'awsconfig', 's3:js', 'cloudfront:prod']);
@@ -385,4 +367,8 @@ module.exports = function(grunt) {
     grunt.registerTask('branchCheck', 'Checks that you are publishing from Master branch with no working changes', ['gitinfo', 'checkBranchStatus']);
 
     grunt.registerTask('cdnify', ['awsconfig', 's3:images']);
+
+    grunt.registerTask('bannerPkg', function(){
+        grunt.log.warn(grunt.config.get('globalVersion'))
+    })
 };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "grunt-cloudfront": "^0.2.1",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-cssmin": "^0.11.0",
     "grunt-contrib-less": "^1.0.0",


### PR DESCRIPTION
#88 fixed the banner for the dist files in the releases, but removed the version from the file on the CDN. I added `globalVersion` in the grunt config and it falls back to the current version in package json.

When we do a version bump, `globalVersion` is increased and then used when uglifying the built file. The deploy task was not setting `globalVersion`. This now works because we expect `globalVersion` to be the right one when we deploy.

I also removed the tasks about compression since it was not used and we'll just change CDN soon to take care of that. 