### PR TITLE
Removed browserify-shim

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,9 +151,6 @@ module.exports = function(grunt) {
             options: {
                 browserifyOptions: {
                     debug: true,
-                    'transform': [
-                        'browserify-shim'
-                    ],
                     standalone: 'SupportKit'
                 }
             }

--- a/example/template/demo.html
+++ b/example/template/demo.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
     <title>Conversation Demo</title>
-    <script src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="../dist/WIDGET_CODE"></script>
     <script>
         /* global SupportKit: false */

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "aws-sdk": "^2.1.35",
     "browserify": "^10.1.3",
-    "browserify-shim": "^3.8.6",
     "chai": "^2.3.0",
     "chai-as-promised": "^5.0.0",
     "chai-things": "^0.2.0",
@@ -90,8 +89,5 @@
       "node-lessify",
       "jstify"
     ]
-  },
-  "browserify-shim": {
-    "jquery": "global:jQuery"
   }
 }


### PR DESCRIPTION
Browserify-shim is aliasing all the `require('jquery')` calls to use `window.$`, but jQuery is still bundled in the final package. Until we figure out how to remove it from there or we just get rid of it, this will at least make use of it.

Since the deployment process is broken in CircleCI, I'll do a manual deployment.