### PR TITLE
Add x-smooch-sdk HTTP header

### DIFF
--- a/src/js/endpoint.js
+++ b/src/js/endpoint.js
@@ -6,6 +6,7 @@ module.exports.appToken = undefined;
 module.exports.jwt = undefined;
 module.exports.appUserId = undefined;
 module.exports.userId = undefined;
+module.exports.sdkVersion = undefined;
 
 module.exports.reset = function() {
     delete this.jwt;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -130,6 +130,8 @@ _.extend(Smooch.prototype, Backbone.Events, {
             return Promise.reject(new Error('init method requires an appToken'));
         }
 
+        endpoint.sdkVersion = this.VERSION;
+
         return this.login(options.userId, options.jwt);
     },
 

--- a/src/js/utils/api.js
+++ b/src/js/utils/api.js
@@ -58,7 +58,8 @@ module.exports.call = function call(options) {
 
     var headers = {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'x-smooch-sdk': 'web/' + endpoint.sdkVersion
     };
 
     if (endpoint.appToken) {


### PR DESCRIPTION
Add the new `x-smooch-sdk` header, keeping the user agent as is.

```
{
      'x-smooch-sdk': 'web/1.0.0',
      'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.80 Safari/537.36',
}
```